### PR TITLE
test(e2e): make baseURL subpath-aware in CI; add manifest test that r…

### DIFF
--- a/e2e/pwa-manifest.spec.ts
+++ b/e2e/pwa-manifest.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test';
+
+test('PWA manifest is served (base-aware)', async ({ page, request, baseURL }) => {
+  // Load the app at whatever baseURL points to.
+  await page.goto('./');
+
+  // Read the exact manifest href from the document.
+  const href = await page.locator('link[rel="manifest"]').first().getAttribute('href');
+  expect(href, 'No <link rel="manifest"> on the page').not.toBeNull();
+
+  // Resolve it against baseURL so subpaths are handled correctly.
+  const manifestURL = new URL(href!, baseURL).toString();
+  const res = await request.get(manifestURL);
+  expect(res.ok(), `Failed to GET manifest at ${manifestURL}`).toBeTruthy();
+
+  const json = await res.json();
+  expect(json).toHaveProperty('name');
+  expect(json).toHaveProperty('icons');
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,6 +2,8 @@
 // Runs tests against the production build to avoid `virtual:pwa-register` issues.
 import { defineConfig, devices } from '@playwright/test';
 
+const SUBPATH = process.env.CI ? '/mushroom-tracker-app/' : '/';
+
 export default defineConfig({
   testDir: './e2e',
   timeout: 30_000,
@@ -15,13 +17,15 @@ export default defineConfig({
   // Always serve the built site for tests (stable for PWA virtual modules)
   webServer: {
     command: 'npm run build && npm run preview -- --strictPort --port=5173',
-    url: 'http://localhost:5173',
-    reuseExistingServer: false, // keep it deterministic
+    // Playwright will wait for this URL to respond; point at the subpath in CI.
+    url: `http://localhost:5173${SUBPATH}`,
+    reuseExistingServer: false,
     timeout: 120_000,
   },
 
   use: {
-    baseURL: 'http://localhost:5173',
+    // Make navigation and request.get() resolve relative to the right base.
+    baseURL: `http://localhost:5173${SUBPATH}`,
     trace: 'retain-on-failure',
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',


### PR DESCRIPTION
…esolves href dynamically